### PR TITLE
Add support for AllOf Inheritance

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,8 @@
+<?php
+
+// Needed to get styleci-bridge loaded
+require_once __DIR__.'/vendor/sllh/php-cs-fixer-styleci-bridge/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+
+return ConfigBridge::create();

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,5 @@
+preset: psr2
+
+finder:
+  exclude:
+    - "tests/fixtures"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7|^5.5",
-        "friendsofphp/php-cs-fixer": "v2.0.0-alpha"
+        "friendsofphp/php-cs-fixer": "v2.0.0-alpha",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.1"
     },
     "suggest": {
         "fabpot/php-cs-fixer": "Allow to automatically fix cs on generated code for better visualisation"

--- a/tests/fixtures/all-of/.jane
+++ b/tests/fixtures/all-of/.jane
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'json-schema-file' => __DIR__ . '/schema.json',
+    'root-class' => 'Test',
+    'namespace' => 'Joli\Jane\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'reference' => false,
+];

--- a/tests/fixtures/all-of/expected/Model/Childtype.php
+++ b/tests/fixtures/all-of/expected/Model/Childtype.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Joli\Jane\Tests\Expected\Model;
+
+class Childtype
+{
+    /**
+     * @var string
+     */
+    protected $childProperty;
+    /**
+     * @var string
+     */
+    protected $inheritedProperty;
+
+    /**
+     * @return string
+     */
+    public function getChildProperty()
+    {
+        return $this->childProperty;
+    }
+
+    /**
+     * @param string $childProperty
+     *
+     * @return self
+     */
+    public function setChildProperty($childProperty = null)
+    {
+        $this->childProperty = $childProperty;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInheritedProperty()
+    {
+        return $this->inheritedProperty;
+    }
+
+    /**
+     * @param string $inheritedProperty
+     *
+     * @return self
+     */
+    public function setInheritedProperty($inheritedProperty = null)
+    {
+        $this->inheritedProperty = $inheritedProperty;
+
+        return $this;
+    }
+}

--- a/tests/fixtures/all-of/expected/Model/Parenttype.php
+++ b/tests/fixtures/all-of/expected/Model/Parenttype.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Joli\Jane\Tests\Expected\Model;
+
+class Parenttype
+{
+    /**
+     * @var string
+     */
+    protected $inheritedProperty;
+
+    /**
+     * @return string
+     */
+    public function getInheritedProperty()
+    {
+        return $this->inheritedProperty;
+    }
+
+    /**
+     * @param string $inheritedProperty
+     *
+     * @return self
+     */
+    public function setInheritedProperty($inheritedProperty = null)
+    {
+        $this->inheritedProperty = $inheritedProperty;
+
+        return $this;
+    }
+}

--- a/tests/fixtures/all-of/expected/Model/Test.php
+++ b/tests/fixtures/all-of/expected/Model/Test.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Joli\Jane\Tests\Expected\Model;
+
+class Test
+{
+    /**
+     * @var Childtype
+     */
+    protected $child;
+    /**
+     * @var Parenttype
+     */
+    protected $parent;
+
+    /**
+     * @return Childtype
+     */
+    public function getChild()
+    {
+        return $this->child;
+    }
+
+    /**
+     * @param Childtype $child
+     *
+     * @return self
+     */
+    public function setChild(Childtype $child = null)
+    {
+        $this->child = $child;
+
+        return $this;
+    }
+
+    /**
+     * @return Parenttype
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @param Parenttype $parent
+     *
+     * @return self
+     */
+    public function setParent(Parenttype $parent = null)
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+}

--- a/tests/fixtures/all-of/expected/Normalizer/ChildtypeNormalizer.php
+++ b/tests/fixtures/all-of/expected/Normalizer/ChildtypeNormalizer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Joli\Jane\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class ChildtypeNormalizer extends SerializerAwareNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if ($type !== 'Joli\\Jane\\Tests\\Expected\\Model\\Childtype') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof \Joli\Jane\Tests\Expected\Model\Childtype) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $object = new \Joli\Jane\Tests\Expected\Model\Childtype();
+        if (property_exists($data, 'childProperty')) {
+            $object->setChildProperty($data->{'childProperty'});
+        }
+        if (property_exists($data, 'inheritedProperty')) {
+            $object->setInheritedProperty($data->{'inheritedProperty'});
+        }
+
+        return $object;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = new \stdClass();
+        if (null !== $object->getChildProperty()) {
+            $data->{'childProperty'} = $object->getChildProperty();
+        }
+        if (null !== $object->getInheritedProperty()) {
+            $data->{'inheritedProperty'} = $object->getInheritedProperty();
+        }
+
+        return $data;
+    }
+}

--- a/tests/fixtures/all-of/expected/Normalizer/NormalizerFactory.php
+++ b/tests/fixtures/all-of/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Joli\Jane\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers   = [];
+        $normalizers[] = new \Joli\Jane\Runtime\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new TestNormalizer();
+        $normalizers[] = new ChildtypeNormalizer();
+        $normalizers[] = new ParenttypeNormalizer();
+
+        return $normalizers;
+    }
+}

--- a/tests/fixtures/all-of/expected/Normalizer/ParenttypeNormalizer.php
+++ b/tests/fixtures/all-of/expected/Normalizer/ParenttypeNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Joli\Jane\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class ParenttypeNormalizer extends SerializerAwareNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if ($type !== 'Joli\\Jane\\Tests\\Expected\\Model\\Parenttype') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof \Joli\Jane\Tests\Expected\Model\Parenttype) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $object = new \Joli\Jane\Tests\Expected\Model\Parenttype();
+        if (property_exists($data, 'inheritedProperty')) {
+            $object->setInheritedProperty($data->{'inheritedProperty'});
+        }
+
+        return $object;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = new \stdClass();
+        if (null !== $object->getInheritedProperty()) {
+            $data->{'inheritedProperty'} = $object->getInheritedProperty();
+        }
+
+        return $data;
+    }
+}

--- a/tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Joli\Jane\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+
+class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if ($type !== 'Joli\\Jane\\Tests\\Expected\\Model\\Test') {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if ($data instanceof \Joli\Jane\Tests\Expected\Model\Test) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $object = new \Joli\Jane\Tests\Expected\Model\Test();
+        if (property_exists($data, 'child')) {
+            $object->setChild($this->serializer->deserialize($data->{'child'}, 'Joli\\Jane\\Tests\\Expected\\Model\\Childtype', 'raw', $context));
+        }
+        if (property_exists($data, 'parent')) {
+            $object->setParent($this->serializer->deserialize($data->{'parent'}, 'Joli\\Jane\\Tests\\Expected\\Model\\Parenttype', 'raw', $context));
+        }
+
+        return $object;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = new \stdClass();
+        if (null !== $object->getChild()) {
+            $data->{'child'} = $this->serializer->serialize($object->getChild(), 'raw', $context);
+        }
+        if (null !== $object->getParent()) {
+            $data->{'parent'} = $this->serializer->serialize($object->getParent(), 'raw', $context);
+        }
+
+        return $data;
+    }
+}

--- a/tests/fixtures/all-of/schema.json
+++ b/tests/fixtures/all-of/schema.json
@@ -1,0 +1,37 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Testing allOf",
+    "type": "object",
+    "definitions": {
+        "childtype": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/parenttype"
+                }
+            ],
+            "properties": {
+                "childProperty": {
+                    "type": "string"
+                }
+            }
+        },
+        "parenttype": {
+            "type": "object",
+            "properties": {
+                "inheritedProperty": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "properties": {
+        "child": {
+            "$ref": "#/definitions/childtype"
+        },
+        "parent": {
+            "$ref": "#/definitions/parenttype"
+        }
+    }
+}


### PR DESCRIPTION
Resolves janephp/openapi#32, janephp/openapi#33.
Closes janephp/openapi#34

The properties of the model will be include the properties of the object
that have been included in the AllOf property in the schema. It supports
both references and real definitions.

This also adds the test fixtures directory to those ignored by StyleCI. This is because the standard the code that is generated follows is slightly different to that defined in StyleCI.