### PR TITLE
When generating the denormalize method, add an is_object check, and throw an Exception otherwise

### DIFF
--- a/src/Generator/Normalizer/DenormalizerGenerator.php
+++ b/src/Generator/Normalizer/DenormalizerGenerator.php
@@ -83,6 +83,15 @@ trait DenormalizerGenerator
             ];
         }
 
+        array_unshift($statements, new Stmt\If_(
+            new Expr\BooleanNot(new Expr\FuncCall(new Name('is_object'), [new Arg(new Expr\Variable('data'))])),
+            [
+                'stmts' => [
+                    new Stmt\Throw_(new Expr\New_(new Name('InvalidArgumentException')))
+                ]
+            ]
+        ));
+
         foreach ($properties as $property) {
             $propertyVar = new Expr\PropertyFetch(new Expr\Variable('data'), sprintf("{'%s'}", $property->getName()));
             list($denormalizationStatements, $outputVar) = $property->getType()->createDenormalizationStatement($context, $propertyVar);

--- a/src/Generator/NormalizerGenerator.php
+++ b/src/Generator/NormalizerGenerator.php
@@ -81,6 +81,7 @@ class NormalizerGenerator implements GeneratorInterface
 
             $namespace = new Stmt\Namespace_(new Name($schema->getNamespace()."\\Normalizer"), [
                 new Stmt\Use_([new Stmt\UseUse(new Name('Joli\Jane\Runtime\Reference'))]),
+                new Stmt\Use_([new Stmt\UseUse(new Name('Symfony\Component\Serializer\Exception\InvalidArgumentException'))]),
                 new Stmt\Use_([new Stmt\UseUse(new Name('Symfony\Component\Serializer\Normalizer\DenormalizerInterface'))]),
                 new Stmt\Use_([new Stmt\UseUse(new Name('Symfony\Component\Serializer\Normalizer\NormalizerInterface'))]),
                 new Stmt\Use_([new Stmt\UseUse(new Name('Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer'))]),

--- a/src/Normalizer/JsonSchemaNormalizer.php
+++ b/src/Normalizer/JsonSchemaNormalizer.php
@@ -3,6 +3,7 @@
 namespace Joli\Jane\Normalizer;
 
 use Joli\Jane\Runtime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -29,6 +30,9 @@ class JsonSchemaNormalizer extends SerializerAwareNormalizer implements Denormal
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }

--- a/tests/fixtures/all-of/expected/Normalizer/ChildtypeNormalizer.php
+++ b/tests/fixtures/all-of/expected/Normalizer/ChildtypeNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -28,6 +29,9 @@ class ChildtypeNormalizer extends SerializerAwareNormalizer implements Denormali
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         $object = new \Joli\Jane\Tests\Expected\Model\Childtype();
         if (property_exists($data, 'childProperty')) {
             $object->setChildProperty($data->{'childProperty'});

--- a/tests/fixtures/all-of/expected/Normalizer/ParenttypeNormalizer.php
+++ b/tests/fixtures/all-of/expected/Normalizer/ParenttypeNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -28,6 +29,9 @@ class ParenttypeNormalizer extends SerializerAwareNormalizer implements Denormal
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         $object = new \Joli\Jane\Tests\Expected\Model\Parenttype();
         if (property_exists($data, 'inheritedProperty')) {
             $object->setInheritedProperty($data->{'inheritedProperty'});

--- a/tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -28,6 +29,9 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         $object = new \Joli\Jane\Tests\Expected\Model\Test();
         if (property_exists($data, 'child')) {
             $object->setChild($this->serializer->deserialize($data->{'child'}, 'Joli\\Jane\\Tests\\Expected\\Model\\Childtype', 'raw', $context));

--- a/tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
@@ -3,6 +3,7 @@
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
 use Joli\Jane\Runtime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -29,6 +30,9 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }

--- a/tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -3,6 +3,7 @@
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
 use Joli\Jane\Runtime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -29,6 +30,9 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }

--- a/tests/fixtures/multi-files/expected/Normalizer/FooNormalizer.php
+++ b/tests/fixtures/multi-files/expected/Normalizer/FooNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -28,6 +29,9 @@ class FooNormalizer extends SerializerAwareNormalizer implements DenormalizerInt
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         $object = new \Joli\Jane\Tests\Expected\Model\Foo();
         if (property_exists($data, 'foo')) {
             $object->setFoo($data->{'foo'});

--- a/tests/fixtures/multi-files/expected/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/multi-files/expected/Normalizer/TestNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -28,6 +29,9 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         $object = new \Joli\Jane\Tests\Expected\Model\Test();
         if (property_exists($data, 'foo')) {
             $object->setFoo($this->serializer->deserialize($data->{'foo'}, 'Joli\\Jane\\Tests\\Expected\\Model\\Foo', 'raw', $context));

--- a/tests/fixtures/multi-namespace/expected/Schema1/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/multi-namespace/expected/Schema1/Normalizer/TestNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Joli\Jane\Tests\Expected\Schema1\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -28,6 +29,9 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         $object = new \Joli\Jane\Tests\Expected\Schema1\Model\Test();
         if (property_exists($data, 'foo')) {
             $object->setFoo($this->serializer->deserialize($data->{'foo'}, 'Joli\\Jane\\Tests\\Expected\\Schema2\\Model\\Foo', 'raw', $context));

--- a/tests/fixtures/multi-namespace/expected/Schema2/Normalizer/FooNormalizer.php
+++ b/tests/fixtures/multi-namespace/expected/Schema2/Normalizer/FooNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Joli\Jane\Tests\Expected\Schema2\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -28,6 +29,9 @@ class FooNormalizer extends SerializerAwareNormalizer implements DenormalizerInt
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         $object = new \Joli\Jane\Tests\Expected\Schema2\Model\Foo();
         if (property_exists($data, 'foo')) {
             $object->setFoo($data->{'foo'});

--- a/tests/fixtures/test-no-reference/expected/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/test-no-reference/expected/Normalizer/TestNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -28,6 +29,9 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         $object = new \Joli\Jane\Tests\Expected\Model\Test();
         if (property_exists($data, 'string')) {
             $object->setString($data->{'string'});

--- a/tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
+++ b/tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
@@ -3,6 +3,7 @@
 namespace Joli\Jane\Tests\Expected\Normalizer;
 
 use Joli\Jane\Runtime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
@@ -29,6 +30,9 @@ class TestNormalizer extends SerializerAwareNormalizer implements DenormalizerIn
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }


### PR DESCRIPTION
Problem :
------
When denormalizing a json string using a normalizer class generated by Jane, if an array (or an integer) is passed as a value in this json string instead of an array `{'foo': []}` instead of `{'foo': {}}` a warning is emmited : `"Warning: First parameter must either be an object or the name of an existing class"` 

It is because in the generated normalizer, the $data value to be denormalized is not checked before using `property_exists` on it.

It is imho an unexpected behaviour, especially when denormalizing a json string created by a 3rd party, this warning is indeed not usable to raise a more user friendly error message (or anything else)

Solution : 
------
Change the DenormalizerGenerator trait so that all generated denormalize methods first check if the `$data` argument is indeed an object, and throw an Exception if it is not the case.

:heart: 