### PR TITLE
Add ability to define a php-cs-fixer config file to use when generating files

### DIFF
--- a/src/Jane.php
+++ b/src/Jane.php
@@ -48,6 +48,11 @@ class Jane
         $this->fixerConfig = $fixerConfig;
     }
 
+    public function setFixerConfig(ConfigInterface $fixerConfig)
+    {
+        $this->fixerConfig = $fixerConfig;
+    }
+
     /**
      * Return a list of class guessed.
      *


### PR DESCRIPTION
Jane can detect the presence of php-cs-fixer and use it when generating files.

However it is currently impossible to define a CS config file to be used by Jane when using the generate command.

This PR adds a --fixer-config-file=/path/to/.php_cs option to the generate command, where its value is the path to ce cs config file to be used when "fixing" coding standards on generated files.

* [ ] Edit docs
* [ ] Add test